### PR TITLE
Fixes rendering of swerve drive on dashboard

### DIFF
--- a/dashboard/www/index.html
+++ b/dashboard/www/index.html
@@ -12,7 +12,7 @@
     <script src="/networktables/networktables.js"></script>
 
 
-    <!-- Obviously, you will want to copy this file locally in a real 
+    <!-- Obviously, you will want to copy this file locally in a real
      dashboard, as the Driver Station won't have internet access -->
     <script src="https://code.jquery.com/jquery-2.2.2.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/d3/3.5.14/d3.min.js"></script>
@@ -135,6 +135,11 @@
                     height: 480,                    // optional, stretches image to this width
                 }
             });
+            window.swerveDriveImage = new Image();
+            window.swerveDriveImage.src = 'resources/swerveModule.png'
+            window.swerveDriveImage.addEventListener("load", function() {
+                console.log("image is loaded");
+            }, false);
         });
 
         function swerveListener(key, value, isNew) {
@@ -143,11 +148,10 @@
             var canvas = document.getElementById('SwerveCanvas');
             if (canvas.getContext) {
                 var lf = canvas.getContext('2d');
-                var swerveDriveImage = new Image();
-                swerveDriveImage.src = 'resources/swerveModule.png'
 
                 //console.log(key, value)
-                if (key == "/SmartDashboard/SwerveDrive/fp_actual") {
+                if (key == "/SmartDashboard/SwerveDrive/fp_target") {
+                    console.log("New info on target!");
                     lf.clearRect(0, 0, 150, 150);
                     //save the untranslated/unrotated context
                     lf.save();
@@ -159,42 +163,43 @@
                     //draw the rect on the transformed context
                     //Note: after transforming [0,0] is visually [x,y]
                     //so the rect needs to be offset accordingly when drawn
-                    lf.drawImage(swerveDriveImage, -39 / 2, -48 / 2);
+                    lf.drawImage(window.swerveDriveImage, -39 / 2, -48 / 2);
                     lf.fill();
                     //restore the context to its untranslated/unrotated state
                     lf.restore();
+
                 }
 
 
-                if (key == "/SmartDashboard/SwerveDrive/fs_actual") {
+                if (key == "/SmartDashboard/SwerveDrive/fs_target") {
                     lf.clearRect(150, 0, canvas.width, 150);
                     lf.save();
                     lf.beginPath();
                     lf.translate(200 + 50 / 2, 25 + 75 / 2);
                     lf.rotate(value);
-                    lf.drawImage(swerveDriveImage, -39 / 2, -48 / 2);
+                    lf.drawImage(window.swerveDriveImage, -39 / 2, -48 / 2);
                     lf.fill();
                     lf.restore();
                 }
 
-                if (key == "/SmartDashboard/SwerveDrive/ap_actual") {
+                if (key == "/SmartDashboard/SwerveDrive/ap_target") {
                     lf.clearRect(0, 150, 150, canvas.height);
                     lf.save();
                     lf.beginPath();
                     lf.translate(50, 300 + 75);
                     lf.rotate(value);
-                    lf.drawImage(swerveDriveImage, -39 / 2, -48 / 2);
+                    lf.drawImage(window.swerveDriveImage, -39 / 2, -48 / 2);
                     lf.fill();
                     lf.restore();
                 }
 
-                if (key == "/SmartDashboard/SwerveDrive/as_actual") {
+                if (key == "/SmartDashboard/SwerveDrive/as_target") {
                     lf.clearRect(150, 150, canvas.width, canvas.height);
                     lf.save();
                     lf.beginPath();
                     lf.translate(175 + 50, 300 + 75);
                     lf.rotate(value);
-                    lf.drawImage(swerveDriveImage, -39 / 2, -48 / 2);
+                    lf.drawImage(window.swerveDriveImage, -39 / 2, -48 / 2);
                     lf.fill();
                     lf.restore();
                 }

--- a/rio/constants/robot_controls.yaml
+++ b/rio/constants/robot_controls.yaml
@@ -1,5 +1,5 @@
 # This file defines the input
-# and control scheme of the robot, 
+# and control scheme of the robot,
 # Arranged into operating "modes"
 
 mode_a:


### PR DESCRIPTION
We were unnecessarily reloading the image every time we received a NetworkTables update. This moves the image loading to outside the update loop.